### PR TITLE
feat: add sorting to users table

### DIFF
--- a/components/AppTable.vue
+++ b/components/AppTable.vue
@@ -4,7 +4,19 @@
       <thead>
         <tr>
           <th></th>
-          <th v-for="(header, index) in headers" :key="index">{{ header }}</th>
+          <th v-for="(header, index) in headers" :key="index">
+            <span
+              v-if="isSortable(header)"
+              class="sortable"
+              @click="sortTable(header)"
+            >
+              {{ header }}
+              <span v-if="sortKey === header">
+                {{ sortAsc ? '▲' : '▼' }}
+              </span>
+            </span>
+            <span v-else>{{ header }}</span>
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -40,11 +52,40 @@ const emit = defineEmits<{
 const tableData = ref<TableRow[]>([...props.initialData]);
 const headers = ref<string[]>([]);
 
+const sortableHeaders = ['firstName', 'lastName'];
+const sortKey = ref<string | null>(null);
+const sortAsc = ref(true);
+
+const isSortable = (header: string) => sortableHeaders.includes(header);
+
+const applySort = () => {
+  if (!sortKey.value) return;
+  const key = sortKey.value;
+  tableData.value.sort((a, b) => {
+    const aVal = a[key];
+    const bVal = b[key];
+    if (aVal < bVal) return sortAsc.value ? -1 : 1;
+    if (aVal > bVal) return sortAsc.value ? 1 : -1;
+    return 0;
+  });
+};
+
+const sortTable = (key: string) => {
+  if (sortKey.value === key) {
+    sortAsc.value = !sortAsc.value;
+  } else {
+    sortKey.value = key;
+    sortAsc.value = true;
+  }
+  applySort();
+};
+
 watchEffect(() => {
   if (props.initialData.length > 0) {
     headers.value = Object.keys(props.initialData[0]);
   }
   tableData.value = [...props.initialData];
+  applySort();
 });
 
 const selectedRow = ref<TableRow | null>(null);
@@ -78,5 +119,9 @@ th {
 input[type='checkbox'] {
   width: 16px;
   height: 16px;
+}
+
+.sortable {
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
## Summary
- allow sorting of users by `firstName` and `lastName`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689387235bd48325a092e102193caa40